### PR TITLE
Publish CLI binary when create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release Go Binaries
+
+on: 
+  release:
+    types: [created]
+
+jobs:
+  releases-matrix:
+    name: gnostic
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set APP_VERSION env
+      run: echo ::set-env name=APP_VERSION::$(basename ${GITHUB_REF})
+    - name: Set BUILD_TIME env
+      run: echo ::set-env name=BUILD_TIME::$(date)
+    - name: Environment Printer
+      uses: managedkaos/print-env@v1.0
+
+    - uses: wangyoucao577/go-release-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz"
+        project_path: "./"
+        binary_name: gnostic
+        build_flags: -v
+
+        
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set APP_VERSION env
-      run: echo ::set-env name=APP_VERSION::$(basename ${GITHUB_REF})
-    - name: Set BUILD_TIME env
-      run: echo ::set-env name=BUILD_TIME::$(date)
-    - name: Environment Printer
-      uses: managedkaos/print-env@v1.0
-
     - uses: wangyoucao577/go-release-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +23,6 @@ jobs:
         goversion: "https://golang.org/dl/go1.15.3.linux-amd64.tar.gz"
         project_path: "./"
         binary_name: gnostic
-        build_flags: -v
 
         
 


### PR DESCRIPTION
So that people don't need to install `Go` in their local.

For example: https://github.com/wangyoucao577/gnostic/releases/tag/v0.5.3-testonly

After merge this PR, you can

- Create a release
- Wait a few minutes, then you'll see the binaries automatically published to this release.       


